### PR TITLE
Bugfix: reinitialize current page during gene search

### DIFF
--- a/frontend/src/containers/SearchTable.jsx
+++ b/frontend/src/containers/SearchTable.jsx
@@ -8,6 +8,8 @@ import { Input, Table } from 'antd';
 
 import './SearchTable.css';
 
+const DEFAULT_PAGE = 1;
+
 export default class SearchTable extends Component {
     columns = [
         {
@@ -63,7 +65,7 @@ export default class SearchTable extends Component {
     ];
 
     state = {
-        currentPage: 1,
+        currentPage: DEFAULT_PAGE,
         data: [],
         geneSearch: null,
         geneSuggestions: [],
@@ -85,8 +87,8 @@ export default class SearchTable extends Component {
             isLoading: true
         }, async () => {
             const url = this.state.geneSearch ?
-                `http://localhost:8000/variants/?page=${this.state.currentPage}&search=${this.state.geneSearch}` :
-                `http://localhost:8000/variants/?page=${this.state.currentPage}`;
+                `http://localhost:8000/variants/?page=${pageNumber}&search=${this.state.geneSearch}` :
+                `http://localhost:8000/variants/?page=${pageNumber}`;
             const response = await fetch(url);
             const data = await response.json();
             this.setState({
@@ -97,14 +99,18 @@ export default class SearchTable extends Component {
         });
     }
 
+    async loadDataForCurrentPage() {
+        return this.loadDataForPage(this.state.currentPage)
+    }
+
     async componentDidMount() {
-        await this.loadDataForPage(this.state.currentPage);
+        await this.loadDataForCurrentPage();
     }
 
     handlePaginationChange = async (newPage) => {
         this.setState({
             currentPage: newPage
-        }, () => this.loadDataForPage(this.state.currentPage));
+        }, () => this.loadDataForCurrentPage());
     };
 
     handleSearch = async (e) => {
@@ -114,17 +120,12 @@ export default class SearchTable extends Component {
         if (data.results.length === 1) {
             const { gene } = data.results[0];
             this.setState({
+                currentPage: DEFAULT_PAGE,
                 geneSearch: gene,
-            }, () => this.loadDataForPage(this.state.currentPage));
+            }, () => this.loadDataForCurrentPage());
         } else {
             this.setState({data:[], totalCount:0});
         }
-    };
-
-    handleGeneSelect = (value) => {
-        this.setState({
-            geneSearch: value.toString()
-        }, () => this.loadDataForPage(this.state.currentPage));
     };
 
     render() {
@@ -143,7 +144,8 @@ export default class SearchTable extends Component {
                     pagination={{
                         pageSize: 15,
                         total: this.state.totalCount,
-                        onChange: this.handlePaginationChange
+                        onChange: this.handlePaginationChange,
+                        current: this.state.currentPage
                     }}
                 />
             </div>


### PR DESCRIPTION
## Original Issue

This PR fixes a bug recently discovered by a candidate.

The bug can be reproduced by loading the site, by clicking one of the pages in the pagination list and then using the gene search dialog. Frontend error screenshot:

<img width="761" alt="Screen Shot 2021-01-13 at 11 49 43 AM" src="https://user-images.githubusercontent.com/61755432/104496292-c7cd8880-55a6-11eb-9b1f-11677c7ab5f6.png">

The fix is not trivial because of an implementation detail of the antd `Table` component (https://stackoverflow.com/questions/54730896/antd-table-pagination-show-no-data-when-moved-to-second-page), so I figured it would be best to fix this in the repository rather than ask candidates to fix it if they happened to discover the issue during the exercise.

## Changes

 * In addition to setting the state for the selected gene, reinitialize the current page to the default value in order to avoid a TypeError exception.
 * Add `current` setting to pagination configuration in order to workaround an issue where "No Data" is rendered by the Table component on initial load of the gene search. This is documented in the above StackOverflow link.
 * Remove unused `handleGeneSelect` function.

## Testing Done

Tested the frontend locally in Chrome to confirm the issue is fixed and there are no breakages caused by this change.