### PR TITLE
Downgrade Node

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node
+FROM node:16-alpine3.12
 
 WORKDIR /opt/frontend
 COPY package.json .


### PR DESCRIPTION
There is currently an issue in the latest version of node which is causing this error: https://github.com/webpack/webpack/issues/14532

This PR downgrades the version of node we use to avoid it.

