### PR TITLE
chore: pin python in dockerfile

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.9
 ENV PYTHONUNBUFFERED 1
 
 WORKDIR /opt/backend


### PR DESCRIPTION
the project relies on django 2, and not pinning python version installs python 3.12 which doesn't work with django 2.